### PR TITLE
Move `StaticArrayStyle` here.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StaticArraysCore"
 uuid = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
-version = "1.1.0"
+version = "1.1.1"
 
 [compat]
 julia = "1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StaticArraysCore"
 uuid = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
-version = "1.1.1"
+version = "1.2.0"
 
 [compat]
 julia = "1.6"

--- a/src/StaticArraysCore.jl
+++ b/src/StaticArraysCore.jl
@@ -384,4 +384,9 @@ array operations as in the example below.
 """
 abstract type FieldVector{N, T} <: FieldArray{Tuple{N}, T, 1} end
 
+# Add a new BroadcastStyle for StaticArrays, derived from AbstractArrayStyle
+# A constructor that changes the style parameter N (array dimension) is also required
+struct StaticArrayStyle{N} <: Base.Broadcast.AbstractArrayStyle{N} end
+StaticArrayStyle{M}(::Val{N}) where {M,N} = StaticArrayStyle{N}()
+
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,4 +22,6 @@ using StaticArraysCore, Test
     @test StaticArraysCore.tuple_length((5, 3)) == 2
     @test StaticArraysCore.tuple_prod((5, 3)) == 15
     @test StaticArraysCore.tuple_minimum((5, 3)) == 3
+
+    @test StaticArraysCore.StaticArrayStyle{1}(Val(2)) === StaticArraysCore.StaticArrayStyle{2}()
 end


### PR DESCRIPTION
This PR wants to move ~`Size`~, `StaticArrayStyle`, ~`is_staticarray_like` (renamed from `isstatic`)~, and ~`similar_type`~ into Core package.
These functions are needed in `StructArrays.jl` to support static broadcast for a `StructArray` of `StaticArray`s. https://github.com/JuliaArrays/StructArrays.jl/pull/215#issuecomment-1196221194
Edit: It turns out we only need `StaticArrayStyle` and `similar_type` to achieve this. Since `similar_type` has been taken care by https://github.com/JuliaArrays/StaticArraysCore.jl/pull/5
This PR only wants to move `StaticArrayStyle` here.
