### PR TITLE
fix return type inference failure for `Size`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StaticArraysCore"
 uuid = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
-version = "1.4.0"
+version = "1.4.1"
 
 [compat]
 julia = "1.6"

--- a/src/StaticArraysCore.jl
+++ b/src/StaticArraysCore.jl
@@ -491,6 +491,6 @@ Size(a::T) where {T<:AbstractArray} = Size(T)
 Size(::Type{SA}) where {SA <: StaticArray} = missing_size_error(SA)
 Size(::Type{SA}) where {SA <: StaticArray{S}} where {S<:Tuple} = @isdefined(S) ? Size(S) : missing_size_error(SA)
 
-Base.@pure Size(::Type{<:AbstractArray{<:Any, N}}) where {N} = Size(ntuple(_ -> Dynamic(), Val(N)))
+Size(::Type{<:AbstractArray{<:Any, N}}) where {N} = Size(ntuple(_ -> Dynamic(), Val(N)))
 
 end # module

--- a/src/StaticArraysCore.jl
+++ b/src/StaticArraysCore.jl
@@ -491,6 +491,6 @@ Size(a::T) where {T<:AbstractArray} = Size(T)
 Size(::Type{SA}) where {SA <: StaticArray} = missing_size_error(SA)
 Size(::Type{SA}) where {SA <: StaticArray{S}} where {S<:Tuple} = @isdefined(S) ? Size(S) : missing_size_error(SA)
 
-Base.@pure Size(::Type{<:AbstractArray{<:Any, N}}) where {N} = Size(ntuple(_ -> Dynamic(), N))
+Base.@pure Size(::Type{<:AbstractArray{<:Any, N}}) where {N} = Size(ntuple(_ -> Dynamic(), Val(N)))
 
 end # module


### PR DESCRIPTION
The `ntuple` function has a method that takes a `Val` argument instead of an `Integer` as the second parameter. Using it helps Julia with type inference in some cases, in particular when the value of the argument is known when the code is being compiled and when it is greater than ten (with current Julia versions).

With Julia master, the following code demonstrates the fixed issue. It errors with StaticArraysCore master, but passes with this commit:
```julia
using Test, StaticArraysCore

@inferred Size(Array{Float64, 11})
```