### PR TITLE
improve implementations of the `tuple_` functions, removing `@pure`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StaticArraysCore"
 uuid = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
-version = "1.4.1"
+version = "1.4.2"
 
 [compat]
 julia = "1.6"


### PR DESCRIPTION
The new method definitions make `Base.@pure` annotations for these methods unnecessary.