### PR TITLE
NamedTuple Constructor Support for FieldArray Subtypes

### DIFF
--- a/src/StaticArraysCore.jl
+++ b/src/StaticArraysCore.jl
@@ -319,6 +319,9 @@ consider defining `similar_type` as in the `FieldVector` example.
 """
 abstract type FieldArray{N, T, D} <: StaticArray{N, T, D} end
 
+Base.convert(::Type{NamedTuple}, array::FieldArray) = Base.NamedTuple(array)
+Base.NamedTuple(array::FieldArray) = Base.NamedTuple{propertynames(array)}(array)
+
 """
     abstract FieldMatrix{N1, N2, T} <: FieldArray{Tuple{N1, N2}, 2}
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,6 +24,15 @@ using StaticArraysCore, Test
     @test StaticArraysCore.tuple_minimum((5, 3)) == 3
 
     @test StaticArraysCore.StaticArrayStyle{1}(Val(2)) === StaticArraysCore.StaticArrayStyle{2}()
+
+    struct __FieldArrayTest <: FieldVector{3,Float64}
+        a::Float64
+        b::Float64
+        c::Float64
+    end
+
+    @test __FieldArrayTest(1,2,3) isa SizedArray
+    @test convert(NamedTuple, __FieldArrayTest(1,2,3)) isa NamedTuple
 end
 
 @testset "Size" begin


### PR DESCRIPTION
I have found `NamedTuple` to be a performant way to initialize `FieldArray` subtypes. See, for example, the following code in [`AstrodynamicalModels.jl`](https://github.com/cadojo/AstrodynamicalModels.jl/blob/8c811923c2d56b7927bf4c62acc2fbfa1bcd91d4/src/AstrodynamicalModels.jl#L107). I think it may also be useful sometimes to go in reverse: convert a `FieldArray` subtype back into a `NamedTuple`. **Do you agree this may be useful, and without undesirable side effects?** If so, should this PR include a `Base.convert` method too? 

I got this idea from `SciML`'s [`Base.NamedTuple` method](https://github.com/SciML/LabelledArrays.jl/blob/d652e95b08b28260d36ca1ce34af1d02fd5506d0/src/LabelledArrays.jl#L59) for `LabelledArrays.jl`. 

Thanks for reading!

```julia
"""
A mutable vector, with labels, for 6DOF Cartesian states.
"""
Base.@kwdef mutable struct CartesianState{F} <: FieldVector{6,F}
    x::F = 0.0
    y::F = 0.0
    z::F = 0.0
    ẋ::F = 0.0
    ẏ::F = 0.0
    ż::F = 0.0

    CartesianState{F}(::UndefInitializer) where {F} = new{F}()
    CartesianState(::UndefInitializer) = CartesianState{Float64}(undef)

    CartesianState{F}(x, y, z, ẋ, ẏ, ż) where {F} = new{F}(x, y, z, ẋ, ẏ, ż)
    CartesianState(x, y, z, ẋ, ẏ, ż) = new{promote_type(typeof(x), typeof(y), typeof(z), typeof(ẋ), typeof(ẏ), typeof(ż))}(x, y, z, ẋ, ẏ, ż)
    CartesianState{F}(state::NamedTuple) where {F} =
        let
            (; x, y, z, ẋ, ẏ, ż) = merge((; x=zero(F), y=zero(F), z=zero(F), ẋ=zero(F), ẏ=zero(F), ż=zero(F)), state)
            CartesianState{F}(x, y, z, ẋ, ẏ, ż)
        end
    CartesianState(state::NamedTuple) = CartesianState{Float64}(state)
end
```
