### PR TITLE
Make empty `Size()` type stable

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StaticArraysCore"
 uuid = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
-version = "1.4.2"
+version = "1.4.3"
 
 [compat]
 julia = "1.6"

--- a/src/StaticArraysCore.jl
+++ b/src/StaticArraysCore.jl
@@ -491,6 +491,7 @@ end
 
 Base.@pure Size(s::Tuple{Vararg{StaticDimension}}) = Size{s}()
 Base.@pure Size(s::StaticDimension...) = Size{s}()
+Size() = Size(())
 Size(::Type{T}) where {T<:Tuple} = Size{tuple_tuple(T)}()
 
 Base.show(io::IO, ::Size{S}) where {S} = print(io, "Size", S)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,6 +29,7 @@ end
 @testset "Size" begin
     M = SArray{Tuple{2,3,4},Int,3}(tuple(rand(Int, 24)...))
     @test (@inferred Size(M)) === Size(2, 3, 4)
+    @test (@inferred Size()) === Size{()}()
     Ms = Size(M)
     @test repr(Ms) == "Size(2, 3, 4)"
     @test Size(2, StaticArraysCore.Dynamic(), 5) === Size{(2, StaticArraysCore.Dynamic(), 5)}()


### PR DESCRIPTION
The `Size()` constructor (used with no arguments) is currently type unstable, at least on Julia 1.10:

```julia
julia> @code_warntype Size()
MethodInstance for Size()
  from Size(s::Union{StaticArraysCore.Dynamic, Int64}...) @ StaticArraysCore ~/.julia/packages/StaticArraysCore/P6PH7/src/StaticArraysCore.jl:476
Arguments
  #self#::Type{Size}
  s::Tuple{}
Body::Size   # <-- in red
1 ─      nothing
│   %2 = Core.apply_type(StaticArraysCore.Size, s)::Type{Size{_A}} where _A   # <-- in red
│   %3 = (%2)()::Size   # <-- in red
└──      return %3
```

This doesn't seem to be related to the `@pure` annotations in the `Size` constructors.

This PR fixes this issue by explicitly creating a `Size()` constructor which is type stable.

---

For context, this seems to fix an obscure type stability issue I identified when broadcasting a `Number` and a `SVector`, which only manifests when Julia is launched with `--check-bounds=no`. This looks similar to https://github.com/JuliaArrays/StaticArrays.jl/issues/1155, but I'm not sure it's exactly the same issue.

As an example:

```julia
using StaticArrays
x = 0.3
y = SVector(0.1, 0.2, 0.3)
@code_warntype x .+ y
```

On Julia 1.10.4 started with default flags everything looks fine:

```julia
julia> @code_warntype x .+ y
MethodInstance for (::var"##dotfunction#225#1")(::Float64, ::SVector{3, Float64})
  from (::var"##dotfunction#225#1")(x1, x2) @ Main none:0
Arguments
  #self#::Core.Const(var"##dotfunction#225#1"())
  x1::Float64
  x2::SVector{3, Float64}
Body::SVector{3, Float64}
1 ─ %1 = Base.broadcasted(Main.:+, x1, x2)::Base.Broadcast.Broadcasted{StaticArraysCore.StaticArrayStyle{1}, Nothing, typeof(+), Tuple{Float64, SVector{3, Float64}}}
│   %2 = Base.materialize(%1)::SVector{3, Float64}
└──      return %2
```

When Julia is launched with `--check-bounds=no`:


```julia
julia> @code_warntype x .+ y
MethodInstance for (::var"##dotfunction#225#1")(::Float64, ::SVector{3, Float64})
  from (::var"##dotfunction#225#1")(x1, x2) @ Main none:0
Arguments
  #self#::Core.Const(var"##dotfunction#225#1"())
  x1::Float64
  x2::SVector{3, Float64}
Body::Any
1 ─ %1 = Base.broadcasted(Main.:+, x1, x2)::Base.Broadcast.Broadcasted{StaticArraysCore.StaticArrayStyle{1}, Nothing, typeof(+), Tuple{Float64, SVector{3, Float64}}}
│   %2 = Base.materialize(%1)::Any
└──      return %2
```

The culprit can be tracked down to be the type unstable `Size()` constructor. Note that `Size()` is also unstable without `--check-bounds=no`, but in that case Julia is somehow able to determine the correct return type of the broadcast.