### PR TITLE
Use require_one_based_indexing from Base

### DIFF
--- a/src/StaticArraysCore.jl
+++ b/src/StaticArraysCore.jl
@@ -246,9 +246,6 @@ const MMatrix{S1, S2, T, L} = MArray{Tuple{S1, S2}, T, 2, L}
 
 # SizedArray
 
-require_one_based_indexing(A...) = !Base.has_offset_axes(A...) ||
-    throw(ArgumentError("offset arrays are not supported but got an array with index other than 1"))
-
 """
     SizedArray{Tuple{dims...}}(array)
 
@@ -265,7 +262,7 @@ struct SizedArray{S<:Tuple,T,N,M,TData<:AbstractArray{T,M}} <: StaticArray{S,T,N
     data::TData
 
     function SizedArray{S,T,N,M,TData}(a::TData) where {S<:Tuple,T,N,M,TData<:AbstractArray{T,M}}
-        require_one_based_indexing(a)
+        Base.require_one_based_indexing(a)
         if size(a) != size_to_tuple(S) && size(a) != (tuple_prod(S),)
             throw(DimensionMismatch("Dimensions $(size(a)) don't match static size $S"))
         end


### PR DESCRIPTION
Since this package has a julia lower bound of v1.6, we may reuse the `Base` function instead of redefining it. The function has been in Base from v1.2.